### PR TITLE
Pass -output value through to wget

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func realMain(parent context.Context, manPath, output string, port int) error {
 			"-nv",
 			"-nH",
 			"-P",
-			"./build",
+			output,
 			"-r",
 			"-E",
 			fmt.Sprintf("0.0.0.0:%d", port),


### PR DESCRIPTION
## Summary
- The `-output` flag was parsed but ignored; `wget` always wrote to `./build`. Wires the flag value into `wget -P` so `-output=foo` actually controls the destination.

Closes #4.

## Test plan
- [ ] `go run . -manifest=./example/smolmanifest.json -output=./out` writes the static export under `./out`

🤖 Generated with [Claude Code](https://claude.com/claude-code)