### PR TITLE
Fix wget argv[0] so -nv is honored

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,8 +96,8 @@ func realMain(parent context.Context, manPath, output string, port int) error {
 	}()
 
 	if output != "" {
-		cmd := exec.Command("wget")
-		cmd.Args = []string{
+		cmd := exec.Command(
+			"wget",
 			"-nv",
 			"-nH",
 			"-P",
@@ -105,7 +105,7 @@ func realMain(parent context.Context, manPath, output string, port int) error {
 			"-r",
 			"-E",
 			fmt.Sprintf("0.0.0.0:%d", port),
-		}
+		)
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("error running wget: %s", err)


### PR DESCRIPTION
## Summary
- `exec.Command("wget")` initialized `cmd.Args` to `["wget"]`, then the assignment replaced it with `["-nv", ...]`. wget treats argv[0] as its own program name and discards it, so `-nv` (no-verbose) was silently dropped on every static export.
- Pass all args through `exec.Command`'s varargs instead, which keeps argv[0] correct.

Closes #5.

## Test plan
- [ ] Run with `-output=...`; wget output should now be quiet (`-nv`) instead of fully verbose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)