### PR TITLE
Raise server read/write timeouts

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,8 +73,8 @@ func realMain(parent context.Context, manPath, output string, port int) error {
 		s = http.Server{
 			Addr:         fmt.Sprintf("0.0.0.0:%d", port),
 			Handler:      h,
-			ReadTimeout:  1 * time.Second,
-			WriteTimeout: 1. * time.Second,
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 10 * time.Second,
 		}
 		ctx, cancel = context.WithCancel(parent)
 		errs        = make(chan error)


### PR DESCRIPTION
## Summary
- 1s WriteTimeout could be hit by larger templated pages or by `wget -r` during static export. Bumps to 10s write / 5s read, which is still tight enough to surface real hangs.

Closes #7.

## Test plan
- [ ] Run `make example`, confirm normal pages still serve.
- [ ] Run with `-output` to verify static export completes for the example site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)