### PR TITLE
Use Server.Shutdown for graceful stop

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,9 @@ func realMain(parent context.Context, manPath, output string, port int) error {
 	// Waiting for cancellation signal to stop the server
 	go func() {
 		<-ctx.Done()
-		s.Close()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s.Shutdown(shutdownCtx)
 	}()
 
 	// The server process:


### PR DESCRIPTION
## Summary
- Replace `s.Close()` with `s.Shutdown` (5s deadline) so in-flight requests can finish on Ctrl-C or after a static export completes.

Closes #8.

## Test plan
- [ ] Start the server, hit Ctrl-C, confirm clean exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)